### PR TITLE
Renaming 'plural' bulk methods

### DIFF
--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -344,11 +344,11 @@ class Container:
         not be seekable.
         :param hashkey: the hashkey of the object to stream.
         """
-        with self.get_object_streams_and_size(hashkeys=[hashkey], skip_if_missing=False) as triplets:
+        with self.get_objects_stream_and_size(hashkeys=[hashkey], skip_if_missing=False) as triplets:
             counter = 0
             for obj_hashkey, stream, _ in triplets:
                 counter += 1
-                assert counter == 1, 'There is more than one item returned by get_object_streams_and_size'
+                assert counter == 1, 'There is more than one item returned by get_objects_stream_and_size'
                 assert obj_hashkey == hashkey
 
                 if stream is None:
@@ -357,7 +357,7 @@ class Container:
                 yield stream
 
     @contextmanager
-    def get_object_streams_and_size(self, hashkeys, skip_if_missing=True):  # pylint: disable=too-many-statements
+    def get_objects_stream_and_size(self, hashkeys, skip_if_missing=True):  # pylint: disable=too-many-statements
         """A context manager returning a generator yielding triplets of (hashkey, open stream, size).
 
         :note: the hash keys yielded are often in a *different* order than the original
@@ -367,7 +367,7 @@ class Container:
 
         To use it, you should do something like the following::
 
-            with container.get_object_streams_and_size(hashkeys=hashkeys) as triplets:
+            with container.get_objects_stream_and_size(hashkeys=hashkeys) as triplets:
                 for obj_hashkey, stream, size in triplets:
                     if stream is None:
                         # This should happen only if you pass skip_if_missing=False
@@ -517,11 +517,11 @@ class Container:
 
         yield get_object_stream_generator(hashkeys=hashkeys, skip_if_missing=skip_if_missing)
 
-    def get_object_contents(self, hashkeys, skip_if_missing=True):
+    def get_objects_content(self, hashkeys, skip_if_missing=True):
         """Get the content of a number of objects with given hash keys.
 
         :note: use this method only if you know objects fit in memory.
-            Otherwise, use the ``get_object_streams_and_size`` context manager and
+            Otherwise, use the ``get_objects_stream_and_size`` context manager and
             process the objects one by one.
 
         :param hashkeys: A list of hash kyes of the objects to retrieve.
@@ -529,7 +529,7 @@ class Container:
             are the object contents.
         """
         retrieved = {}
-        with self.get_object_streams_and_size(hashkeys=hashkeys, skip_if_missing=skip_if_missing) as triplets:
+        with self.get_objects_stream_and_size(hashkeys=hashkeys, skip_if_missing=skip_if_missing) as triplets:
             for obj_hashkey, stream, _ in triplets:
                 if stream is None:
                     # This should happen only if skip_if_missing is False

--- a/disk_objectstore/examples/example_objectstore.py
+++ b/disk_objectstore/examples/example_objectstore.py
@@ -163,7 +163,7 @@ def main(num_files, min_size, max_size, directly_to_pack, path, clear, num_bulk_
         """A function to read the data in bulk.
 
         It's defined as a functon so it can be profiled."""
-        return container.get_object_contents(hashkey_list, skip_if_missing=False)
+        return container.get_objects_content(hashkey_list, skip_if_missing=False)
 
     all_hashkeys = [hashkey_mapping[filename] for filename in random_keys]
     start = time.time()
@@ -197,7 +197,7 @@ def main(num_files, min_size, max_size, directly_to_pack, path, clear, num_bulk_
 
     # Retrieve in num_bulk_call chunks
     for chunk_of_hashkeys in split_iterator:
-        raw_retrieved.update(container.get_object_contents(chunk_of_hashkeys, skip_if_missing=False))
+        raw_retrieved.update(container.get_objects_content(chunk_of_hashkeys, skip_if_missing=False))
 
     tot_time = time.time() - start
     print(

--- a/tests/concurrent_tests/periodic_worker.py
+++ b/tests/concurrent_tests/periodic_worker.py
@@ -125,7 +125,7 @@ def main(num_files, min_size, max_size, path, repetitions, wait_time, shared_fol
         random.shuffle(all_hashkeys)
 
         if bulk_read:
-            retrieved_content = container.get_object_contents(all_hashkeys, skip_if_missing=False)
+            retrieved_content = container.get_objects_content(all_hashkeys, skip_if_missing=False)
         else:
             retrieved_content = {}
             for obj_hashkey in all_hashkeys:


### PR DESCRIPTION
I think these new names make more sense than the old ones.
- `get_object_contents` -> `get_objects_content`
- `get_object_streams_and_size` -> `get_objects_stream_and_size`