### PR TITLE
Fix concurrency issues

### DIFF
--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -15,7 +15,9 @@ from sqlalchemy.sql import func
 from sqlalchemy.orm import sessionmaker
 
 from .models import Base, Obj
-from .utils import (nullcontext, HashWriterWrapper, ObjectWriter, PackedObjectReader, StreamDecompresser, is_known_hash)
+from .utils import (
+    HashWriterWrapper, ObjectWriter, PackedObjectReader, StreamDecompresser, chunk_iterator, is_known_hash, nullcontext
+)
 from .exceptions import NotExistent, NotInitialised
 
 ObjQueryResults = namedtuple('ObjQueryResults', ['hashkey', 'offset', 'length', 'compressed', 'size'])
@@ -31,6 +33,18 @@ class Container:
     # Size in bytes of each of the chunks used when (internally) reading or writing in chunks, e.g.
     # when packing.
     _CHUNKSIZE = 65536
+
+    # When performing an `in_` query in SQLite, this is converted to something like
+    # 'SELECT * FROM db_object WHERE db_object.hashkey IN (?, ?)' with parameters = ('hash1', 'hash2')
+    # Now, the maximum number of parameters is limited in SQLite, see variable SQLITE_MAX_VARIABLE_NUMBER
+    # as described in https://www.sqlite.org/limits.html
+    # Now, until recently (at the moment of writing) this defaults to 999 for SQLite versions
+    # prior to 3.32.0 (2020-05-22) or 32766 for SQLite versions after 3.32.0.
+    # So we need to assume that we cannot put more than 999 elements in the `.in_` parameter.
+    # Note that on some OSs, the value is increased at compile time. E.g. on my Mac OS X with python 3.6
+    # compiled with HomeBrew, the limit (I tested it) is 250000.
+    # See also e.g. this comment https://bugzilla.redhat.com/show_bug.cgi?id=1798134
+    _IN_SQL_MAX_LENGTH = 950
 
     def __init__(self, folder):
         """Create the class that represents the container.
@@ -407,6 +421,9 @@ class Container:
             # The try/finally block makes sure we close it at the end, if any was open.
             last_open_file = None
 
+            # Operate on a set - only return once per required hashkey, even if required more than once
+            hashkeys_set = set(hashkeys)
+
             try:
                 hashkeys_in_packs = set()
 
@@ -415,12 +432,16 @@ class Container:
                 # a problem as we then split them by pack). To be checked, performance-wise, if it's better
                 # to order in python instead
                 session = self._get_cached_session()
-                query = session.query(Obj).filter(
-                    Obj.hashkey.in_(hashkeys)
-                ).with_entities(Obj.pack_id, Obj.hashkey, Obj.offset, Obj.length, Obj.compressed,
-                                Obj.size).order_by(Obj.offset)
-                for res in query:
-                    packs[res[0]].append(ObjQueryResults(res[1], res[2], res[3], res[4], res[5]))
+
+                # Operate in chunks, due to the SQLite limits
+                # (see comment above the definition of self._IN_SQL_MAX_LENGTH)
+                for chunk in chunk_iterator(hashkeys_set, size=self._IN_SQL_MAX_LENGTH):
+                    query = session.query(Obj).filter(
+                        Obj.hashkey.in_(chunk)
+                    ).with_entities(Obj.pack_id, Obj.hashkey, Obj.offset, Obj.length, Obj.compressed,
+                                    Obj.size).order_by(Obj.offset)
+                    for res in query:
+                        packs[res[0]].append(ObjQueryResults(res[1], res[2], res[3], res[4], res[5]))
 
                 for pack_int_id, pack_metadata in packs.items():
                     hashkeys_in_packs.update(obj.hashkey for obj in pack_metadata)
@@ -441,14 +462,14 @@ class Container:
                 # Collect loose hash keys that are not found
                 # Reason: a concurrent process might have packed them,
                 # in the meantime.
-                loose_not_found = []
-                for loose_hashkey in set(hashkeys).difference(hashkeys_in_packs):
+                loose_not_found = set()
+                for loose_hashkey in hashkeys_set.difference(hashkeys_in_packs):
                     obj_path = self._get_loose_path_from_hashkey(hashkey=loose_hashkey)
                     try:
                         last_open_file = open(obj_path, mode='rb')
                         yield loose_hashkey, last_open_file, os.path.getsize(obj_path)
                     except FileNotFoundError:
-                        loose_not_found.append(loose_hashkey)
+                        loose_not_found.add(loose_hashkey)
                         continue
                     if last_open_file is not None:
                         if not last_open_file.closed:
@@ -460,11 +481,6 @@ class Container:
                 # are by now in the pack.
                 # If they are not, the object does not exist.
                 if loose_not_found:
-                    # In this case, I do *not* sort them - I expect
-                    # this situation to happen quite rarely, only while
-                    # packing, and it's ok to lose a bit of performance
-                    # in this rare case, but keep the code simpler.
-
                     # IMPORTANT. I need to close the session (and flush the
                     # self._session cache) to refresh the DB, otherwise since I am
                     # reading in WAL mode, I will be keeping to read from the "old"
@@ -478,17 +494,20 @@ class Container:
 
                     packs = defaultdict(list)
                     session = self._get_cached_session()
-                    query = session.query(Obj).filter(
-                        Obj.hashkey.in_(hashkeys)
-                    ).with_entities(Obj.pack_id, Obj.hashkey, Obj.offset, Obj.length, Obj.compressed,
-                                    Obj.size).order_by(Obj.offset)
-                    for res in query:
-                        packs[res[0]].append(ObjQueryResults(res[1], res[2], res[3], res[4], res[5]))
+                    for chunk in chunk_iterator(loose_not_found, size=self._IN_SQL_MAX_LENGTH):
+                        query = session.query(Obj).filter(
+                            Obj.hashkey.in_(chunk)
+                        ).with_entities(Obj.pack_id, Obj.hashkey, Obj.offset, Obj.length, Obj.compressed,
+                                        Obj.size).order_by(Obj.offset)
+                        for res in query:
+                            packs[res[0]].append(ObjQueryResults(res[1], res[2], res[3], res[4], res[5]))
 
-                    # I will construct here the really missing objects
-                    really_not_found = set(loose_not_found)
+                    # I will construct here the really missing objects.
+                    # I make a copy of the set.
+                    really_not_found = loose_not_found.copy()
 
                     for pack_int_id, pack_metadata in packs.items():
+                        # I remove those that I found
                         really_not_found.difference_update(obj.hashkey for obj in pack_metadata)
 
                         pack_path = self._get_pack_path_from_pack_id(str(pack_int_id))
@@ -768,12 +787,12 @@ class Container:
         # maintenance operation, so I don't have to worry about concurrency:
         # If I don't find it here, is should not appear midway during the rest of the process
 
-        # I check the hash keys that are already in the pack
-        existing_packed_hashkeys = session.query(Obj).filter(Obj.hashkey.in_(loose_objects)).with_entities(Obj.hashkey
-                                                                                                          ).all()
-        # The query returns a list of length-1 tuples,
-        # and we need to unpack them
-        existing_packed_hashkeys = [value for value, in existing_packed_hashkeys]
+        existing_packed_hashkeys = []
+
+        for chunk in chunk_iterator(loose_objects, size=self._IN_SQL_MAX_LENGTH):
+            # I check the hash keys that are already in the pack
+            for res in session.query(Obj).filter(Obj.hashkey.in_(chunk)).with_entities(Obj.hashkey).all():
+                existing_packed_hashkeys.append(res[0])
         # I remove them from the loose_objects list
         loose_objects.difference_update(existing_packed_hashkeys)
         # Now, I should be left only with objects with hash keys that are not yet known.

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -342,11 +342,7 @@ class Container:
         :return: a byte stream with the object content.
         """
         with self.get_object_stream(hashkey) as handle:
-            content = handle.read()
-            if not content and hashkey != 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855':
-                raise ValueError('empty data returned! {}, type={}'.format(hashkey, type(handle)))
-
-            return content
+            return handle.read()
 
     @contextmanager
     def get_object_stream(self, hashkey):

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -463,7 +463,9 @@ class Container:
                     obj_path = self._get_loose_path_from_hashkey(hashkey=loose_hashkey)
                     try:
                         last_open_file = open(obj_path, mode='rb')
-                        yield loose_hashkey, last_open_file, os.path.getsize(obj_path)
+                        # I do not use os.path.getsize in case the file has just
+                        # been deleted by a concurrent writer
+                        yield loose_hashkey, last_open_file, os.fstat(last_open_file.fileno()).st_size
                     except FileNotFoundError:
                         loose_not_found.add(loose_hashkey)
                         continue

--- a/disk_objectstore/examples/example_objectstore.py
+++ b/disk_objectstore/examples/example_objectstore.py
@@ -105,7 +105,9 @@ def main(num_files, min_size, max_size, directly_to_pack, path, clear, num_bulk_
 
         # Check that the content is correct
         for filename in retrieved:
-            assert retrieved[filename] == files[filename], 'Mismatch (content) for {}'.format(filename)
+            assert retrieved[filename] == files[filename], 'Mismatch (content) for {}, {} vs {}'.format(
+                filename, retrieved[filename], files[filename]
+            )
 
         # Check that num_files new loose files are present now
         counts = container.count_objects()
@@ -212,6 +214,7 @@ def main(num_files, min_size, max_size, directly_to_pack, path, clear, num_bulk_
     ########################################
     # THIRD: a lot of independent reads, one per object
     random.shuffle(random_keys)
+    retrieved = {}
     start = time.time()
     for filename in random_keys:
         obj_hashkey = hashkey_mapping[filename]
@@ -221,7 +224,9 @@ def main(num_files, min_size, max_size, directly_to_pack, path, clear, num_bulk_
     print('Time to retrieve {} packed objects in random order: {} s'.format(num_files, tot_time))
 
     for filename in retrieved:
-        assert retrieved[filename] == files[filename], 'Mismatch for {}'.format(filename)
+        assert retrieved[filename] == files[filename], 'Mismatch (content) for {}, {} vs {}'.format(
+            filename, retrieved[filename], files[filename]
+        )
 
     print('All tests passed')
 

--- a/disk_objectstore/utils.py
+++ b/disk_objectstore/utils.py
@@ -4,6 +4,7 @@ Some might be useful also for end users, like the wrappers to get streams,
 like the ``LazyOpener``.
 """
 import hashlib
+import itertools
 import os
 import uuid
 import zlib
@@ -543,3 +544,18 @@ class HashWriterWrapper:
     def fileno(self):
         """Return the integer file descriptor of the underlying file object."""
         return self._write_stream.fileno()
+
+
+def chunk_iterator(iterator, size):
+    """Given an iterator, split it in chunks of size `size` (except the last one, that can be shorter).
+
+    Examples:
+
+    - `list(chunk_iterator(range(10), 3))` returns `[(0, 1, 2), (3, 4, 5), (6, 7, 8), (9,)]`
+    - `list(chunk_iterator(range(9), 3))` returns `[(0, 1, 2), (3, 4, 5), (6, 7, 8)]`
+
+    :param iterator: an iterator to divide in chunks
+    :param size: the size of each chunk
+    """
+    iterator = iter(iterator)
+    return iter(lambda: tuple(itertools.islice(iterator, size)), ())

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -77,6 +77,11 @@ def test_deletion_while_open(temp_dir):
         # In either case (I got an exception on Windows, I could delete the file on POSIX)
         # I should still be able to read the correct content.
         # Notably, on POSIX I can read even if the file is not there anymore.
+
+        # I first check that I can get its size
+        assert os.fstat(fhandle.fileno()).st_size == len(content)
+
+        # And that I can read the content
         read_content = fhandle.read()
         assert read_content == content
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,90 @@
+"""Test basic I/O functionality.
+
+This is also a way to verify the behavior of the underlying OS/filesystem.
+"""
+import os
+
+
+def test_concurrent_append_read(temp_dir):
+    """Check what happens when reading a file that is being written in append mode in the meantime."""
+    fname = os.path.join(temp_dir, 'test_file')
+
+    first_part = b'v92jgwkf'
+    intermediate = b'fbd9pjv2klmwg'
+    second_part = b'2flemawlefm'
+
+    with open(fname, 'ab') as write_handle:
+        write_handle.write(first_part)
+        # Flush to make sure everything is out of the buffer and visible to other processes
+        write_handle.flush()
+
+        # Verify that I can open in read ode and that I already find the content,
+        # even if the write_handle is not closed
+        with open(fname, 'rb') as read_handle:
+            # Read the first part, check it's correct
+            read_chunk = read_handle.read(len(first_part))
+            assert read_chunk == first_part
+
+            # Write the intermediate and the second part, and flush out buffers
+            write_handle.write(intermediate)
+            write_handle.write(second_part)
+            write_handle.flush()
+
+            # Check that the file size on disk is the expected one
+            assert os.path.getsize(fname) == len(first_part) + len(intermediate) + len(second_part)
+
+            # Now, jump to the beginning of the second part for reading (skipping 'intermediate')
+            read_handle.seek(len(first_part) + len(intermediate))
+            read_chunk = read_handle.read(len(second_part))
+            assert read_chunk == second_part
+
+
+def test_deletion_while_open(temp_dir):
+    """Check the different behavior of deletion of an open file (in read mode).
+
+    On POSIX: I can delete successfully the file and I can still read the content.
+    On Windows: I cannot delete a file while it is open.
+    """
+    fname = os.path.join(temp_dir, 'test_file')
+
+    content = b'rfr23ewv3wg4w'
+
+    # Write something to the file
+    with open(fname, 'wb') as fhandle:
+        fhandle.write(content)
+
+    # Now open again the file
+    with open(fname, 'rb') as fhandle:
+        # After opening, and before starting to read, I delete the file
+        try:
+            os.remove(fname)
+        except PermissionError as exc:
+            # On Windows, I should get:
+            # PermissionError: [WinError 32] The process cannot access the file because
+            # it is begin used by another process: '<filename>'
+            assert os.name == 'nt', 'I should get a PermissionError only on Windows!'
+
+            # Check the error code
+            # Notes:
+            # - errno.EACCES == 13
+            # - os.streerror(exc.errno) == 'Permission denied'
+            assert exc.errno == 13
+            assert os.path.isfile(fname), 'The file was actually deleted on Windows, unexpected!'
+        else:
+            assert os.name == 'posix', "I should be able to delete a file while it's still open only on POSIX!"
+            assert not os.path.isfile(fname), "The file wasn't really deleted in POSIX, unexpected!"
+
+        # In either case (I got an exception on Windows, I could delete the file on POSIX)
+        # I should still be able to read the correct content.
+        # Notably, on POSIX I can read even if the file is not there anymore.
+        read_content = fhandle.read()
+        assert read_content == content
+
+    # Now the file is closed. On POSIX, I know it's not there.
+    # Let me try to delete it also on Windows.
+    if os.name == 'nt':
+        # Now that the file is closed, I should be able to remove it
+        os.remove(fname)
+
+    # The file should not be there on any platform, now
+    assert not os.path.isfile(fname)

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -3,6 +3,8 @@ import os
 import subprocess
 import sys
 
+import pytest
+
 from disk_objectstore import Container
 
 THIS_FILE_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -11,6 +13,7 @@ CONCURRENT_DIR = os.path.join(THIS_FILE_DIR, 'concurrent_tests')
 NUM_WORKERS = 4
 
 
+@pytest.mark.xfail(os.name == 'nt', reason='Still some problems on Windows, see #4')
 def test_concurrency(temp_dir):
     """Test to run concurrently many workers creating objects, and at the same time one packer.
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -3,8 +3,6 @@ import os
 import subprocess
 import sys
 
-import pytest
-
 from disk_objectstore import Container
 
 THIS_FILE_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -13,7 +11,6 @@ CONCURRENT_DIR = os.path.join(THIS_FILE_DIR, 'concurrent_tests')
 NUM_WORKERS = 4
 
 
-@pytest.mark.xfail(reason='I know this is not yet working. This is tracked in #4')
 def test_concurrency(temp_dir):
     """Test to run concurrently many workers creating objects, and at the same time one packer.
 
@@ -51,12 +48,24 @@ def test_concurrency(temp_dir):
         )
 
     packer_out, packer_err = packer_proc.communicate()
+    if packer_out:
+        print('** STDOUT OF PACKER')
+        print(packer_out.decode('utf8'))
+    if packer_err:
+        print('** STDERR OF PACKER')
+        print(packer_err.decode('utf8'), file=sys.stderr)
     worker_outs = []
     worker_errs = []
-    for worker_proc in worker_procs:
+    for worker_id, worker_proc in enumerate(worker_procs):
         worker_out, worker_err = worker_proc.communicate()
         worker_outs.append(worker_out)
         worker_errs.append(worker_err)
+        if worker_out:
+            print('** STDOUT OF WORKER {}'.format(worker_id))
+            print(worker_out.decode('utf8'))
+        if worker_err:
+            print('** STDERR OF WORKER {}'.format(worker_id), file=sys.stderr)
+            print(worker_err.decode('utf8'), file=sys.stderr)
 
     error_messages = []
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -32,14 +32,14 @@ def test_concurrency(temp_dir):
     os.mkdir(shared_dir)
 
     # Start the packer
-    packer_proc = subprocess.Popen([sys.executable, packer_script, '-p', container_dir, '-r', '5', '-w', '0.83'],
+    packer_proc = subprocess.Popen([sys.executable, packer_script, '-p', container_dir, '-r', '7', '-w', '0.83'],
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
 
     # Start the workers
     worker_procs = []
     for worker_id in range(NUM_WORKERS):
-        options = ['-r', '4', '-w', '0', '-p', container_dir, '-s', shared_dir]
+        options = ['-r', '6', '-w', '0', '-p', container_dir, '-s', shared_dir]
         if worker_id % 2:
             # One every two will read in bulk, the other within a loop
             options += ['-b']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -597,3 +597,16 @@ def test_hash_writer_wrapper(temp_dir, hash_type, expected_hash):
 
     with open(os.path.join(temp_dir, filename), 'rb') as fhandle:
         assert fhandle.read() == content
+
+
+def test_chunk_iterator():
+    """Test the correct functionality of the chunk iterator."""
+    # Using `iter(range())` that is an iterator and does not have a length or allows
+    # getting an element by index (i.e., `iter(range(10))` does not work), to make
+    # sure this works also for iterators and not only for lists or similar
+
+    # Check for lengths exactly multiple of the size
+    assert list(utils.chunk_iterator(iter(range(9)), 3)) == [(0, 1, 2), (3, 4, 5), (6, 7, 8)]
+
+    # Check for lengths that give a remainder
+    assert list(utils.chunk_iterator(iter(range(10)), 3)) == [(0, 1, 2), (3, 4, 5), (6, 7, 8), (9,)]


### PR DESCRIPTION
This fixes #4 
This also fixes #29 by implementing fsync also for packs
There is actually a small issue that randomly occurs, reported at the end of #4 
This has been moved to #37 that is still open, and the test is marked as xfail on windows for now

Now the code should be much more robust for concurrent packing (1 process) with multiple readers.

I also fix another issue, with SQLite not supporting in some cases queries with `.in_` with more than 999 elements. We chunk it and make multiple queries. 

Also, there is a possibility that more subtle bugs are still existing: we'll fix them as they occur