### PR TITLE
Moving benchmarks to a different workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,53 @@
+## Run benchmarks on the three OSs
+## We run only on one python version (a recent one)
+## I think that different python versions might share hardware resources so results might have a much larger fluctuation
+
+name: Performance benchmarks
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+
+  benchmarks:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies (including dev dependencies at frozen version)
+      # I'm using pip install -e to make sure that the coverage properly traces the runs
+      # also of the concurrent tests (maybe we can achieve this differently)
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+        pip install -r dev-requirements.txt
+    - name: Run benchmarks
+      run: pytest --benchmark-only --benchmark-json output.json
+    - name: Store benchmark result
+      ## Run only on push on develop! Otherwise people (or other branches) might access to the github-actions branch
+      ## This is currently disabled because we are in a workflow that has the correct 'on' settings (only push,
+      ## and only 'develop'). Otherwise, enable this
+      #if: "github.event_name == 'push' && github.ref == 'refs/heads/develop'"
+      uses: rhysd/github-action-benchmark@v1
+      with:
+        name: "Benchmark on ${{ matrix.os }}"
+        tool: "pytest"
+        output-file-path: output.json
+        # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
+        github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+        auto-push: true
+        # Show alert with commit comment on detecting possible performance regression
+        alert-threshold: '200%'
+        comment-on-alert: true
+        fail-on-alert: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         pip install -e .
         pip install -r dev-requirements.txt
     - name: Test with pytest
+      # No need to run the benchmarks, they will run in a different workflow
       run: pytest --cov=disk_objectstore --benchmark-skip
     - name: Create xml coverage
       run: coverage xml
@@ -62,20 +63,3 @@ jobs:
         name: disk-objectstore
         ## Commenting the following lines - if often fails, and if at least one manages to push, it should be enough
         # fail_ci_if_error: true
-    - name: Run benchmarks
-      run: pytest --benchmark-only --benchmark-json output.json
-    - name: Store benchmark result
-      # Run only on push on develop! Otherwise people (or other branches) might access to the github-actions branch
-      if: "github.event_name == 'push' && github.ref == 'refs/heads/develop'"
-      uses: rhysd/github-action-benchmark@v1
-      with:
-        name: "Benchmark on ${{ matrix.os }} with Python ${{ matrix.python-version }}"
-        tool: "pytest"
-        output-file-path: output.json
-        # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
-        github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
-        auto-push: true
-        # Show alert with commit comment on detecting possible performance regression
-        alert-threshold: '200%'
-        comment-on-alert: true
-        fail-on-alert: true

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ and does not require a server running.
 |    | |
 |-----|----------------------------------------------------------------------------|
 |Latest release| [![PyPI version](https://badge.fury.io/py/disk-objectstore.svg)](https://badge.fury.io/py/disk-objectstore) [![PyPI pyversions](https://img.shields.io/pypi/pyversions/disk-objectstore.svg)](https://pypi.python.org/pypi/disk-objectstore/) |
-|Build status| [![Build Status](https://github.com/giovannipizzi/disk-objectstore/workflows/Continuous%20integration/badge.svg)](https://github.com/giovannipizzi/disk-objectstore/actions) [![Supported platforms](https://img.shields.io/badge/Supported%20platforms-windows%20%7c%20macos%20%7c%20linux-1f425f.svg)](https://github.com/giovannipizzi/disk-objectstore/actions) [![Coverage Status](https://codecov.io/gh/giovannipizzi/disk-objectstore/branch/develop/graph/badge.svg)](https://codecov.io/gh/giovannipizzi/disk-objectstore) |
+|Build status| [![Build Status](https://github.com/giovannipizzi/disk-objectstore/workflows/Continuous%20integration/badge.svg)](https://github.com/giovannipizzi/disk-objectstore/actions) [![Supported platforms](https://img.shields.io/badge/Supported%20platforms-windows%20%7c%20macos%20%7c%20linux-1f425f.svg)](https://github.com/giovannipizzi/disk-objectstore/actions) [![Coverage Status](https://codecov.io/gh/giovannipizzi/disk-objectstore/branch/develop/graph/badge.svg)](https://codecov.io/gh/giovannipizzi/disk-objectstore) [Performance benchmarks](https://giovannipizzi.github.io/disk-objectstore/dev/bench/) |
 
 
 ## Goal


### PR DESCRIPTION
And run only for one python version
In this way I am trying to ensure they run on different hardware
and (possibly) get more reliable results