### PR TITLE
Add the `has_object` method to the `Container` class

### DIFF
--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -345,6 +345,18 @@ class Container:
         with self.get_object_stream(hashkey) as handle:
             return handle.read()
 
+    def has_object(self, hashkey):
+        """Return whether the container contains an object with the given hashkey.
+
+        :param hashkey: the hashkey of the object.
+        :return: True if the object exists, False otherwise.
+        """
+        try:
+            with self.get_object_stream(hashkey):
+                return True
+        except NotExistent:
+            return False
+
     @contextmanager
     def get_object_stream(self, hashkey):
         """Return a context manager yielding a stream to get the content of an object.

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1183,3 +1183,16 @@ def test_simulate_concurrent_packing_multiple_existing_pack(temp_container, comp
     # Object #2 was not open during the packing operation. Theferore, it should be deleted during packing
     # on *all* filesystems, and here it should not exist anymore
     assert not os.path.exists(loosepath2)
+
+
+def test_has_object(temp_container):
+    """Test the ``Container.has_object`` method."""
+    assert not temp_container.has_object('object')
+
+    # Create an object and test that `has_object` recognizes it
+    hashkey = temp_container.add_object(b'')
+    assert temp_container.has_object(hashkey)
+
+    # Verify that it still works after packing the object
+    temp_container.pack_all_loose()
+    assert temp_container.has_object(hashkey)


### PR DESCRIPTION
Fixes #45 

This simple method returns True if the object with the given hashkey
exists in a particular container and False otherwise.