### PR TITLE
Add `has_object` and `has_objects` methods

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,20 +47,30 @@ def generate_random_data():
     A dictionary is returned, where the key is the data MD5 and the value is the bytes content.
     """
 
-    def _generate_random_data(num_files=100, min_size=0, max_size=1000):
+    def _generate_random_data(num_files=100, min_size=0, max_size=1000, seed=None):
         """Generate a number of byte strings with random content (binary) and random length (in a given range).
 
         :param num_files: the number of files to generate
         :param min_size: the smallest allowed file size
         :param max_size: the smallest allowed file size
+        :param seed: if not None, set that seed for random generation (for reproducible runs)
         :return: a dictionary where the key is the data MD5 and the value is the bytes content
         """
-        files = {}
-        for _ in range(num_files):
-            size = random.randint(min_size, max_size)
-            content = os.urandom(size)
-            md5 = hashlib.md5(content).hexdigest()
-            files[md5] = content
-        return files
+        if seed is not None:
+            # Save the state before changing the seed
+            saved_state = random.getstate()
+            random.seed(seed)
+        try:
+            files = {}
+            for _ in range(num_files):
+                size = random.randint(min_size, max_size)
+                content = os.urandom(size)
+                md5 = hashlib.md5(content).hexdigest()
+                files[md5] = content
+            return files
+        finally:
+            # Reset the state if a seed was provided
+            if seed is not None:
+                random.setstate(saved_state)
 
     yield _generate_random_data

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -6,9 +6,10 @@ import pytest
 
 @pytest.mark.benchmark(group='write', min_rounds=3)
 def test_pack_write(temp_container, generate_random_data, benchmark):
-    """Add a number of objects to the container in packed form, and benchmark write and read speed."""
+    """Add 10000 objects to the container in packed form, and benchmark write and read speed."""
     num_files = 10000
-    data = generate_random_data(num_files=num_files, min_size=0, max_size=1000)
+    # Use a seed for more reproducible runs
+    data = generate_random_data(num_files=num_files, min_size=0, max_size=1000, seed=42)
     data_content = list(data.values())
 
     hashkeys = benchmark(temp_container.add_objects_to_pack, data_content, compress=False)
@@ -20,9 +21,10 @@ def test_pack_write(temp_container, generate_random_data, benchmark):
 
 @pytest.mark.benchmark(group='read')
 def test_pack_read(temp_container, generate_random_data, benchmark):
-    """Add a number of objects to the container in packed form, and benchmark write and read speed."""
+    """Add 10000 objects to the container in packed form, and benchmark write and read speed."""
     num_files = 10000
-    data = generate_random_data(num_files=num_files, min_size=0, max_size=1000)
+    # Use a seed for more reproducible runs
+    data = generate_random_data(num_files=num_files, min_size=0, max_size=1000, seed=42)
     data_content = list(data.values())
 
     hashkeys = temp_container.add_objects_to_pack(data_content, compress=False)
@@ -37,3 +39,45 @@ def test_pack_read(temp_container, generate_random_data, benchmark):
 
     # I use `set(data)` because if they are identical, they get the same UUID
     assert results == expected_results_dict
+
+
+@pytest.mark.benchmark(group='check', min_rounds=3)
+def test_has_objects(temp_container, generate_random_data, benchmark):
+    """Benchmark speed to check object existence.
+
+    Add 10000 objects to the container (half packed, half loose), and benchmark speed to check existence
+    of these 10000 and of 5000 more that do not exist.
+    """
+    num_files_half = 5000
+    # Use a seed for more reproducible runs
+    data_packed = generate_random_data(num_files=num_files_half, min_size=0, max_size=1000, seed=42)
+    data_content_packed = list(data_packed.values())
+
+    hashkeys_packed = temp_container.add_objects_to_pack(data_content_packed, compress=False)
+
+    # Different seed to get different data
+    data_loose = generate_random_data(num_files=num_files_half, min_size=0, max_size=1000, seed=44)
+    data_content_loose = list(data_loose.values())
+
+    hashkeys_loose = []
+    for content in data_content_loose:
+        hashkeys_loose.append(temp_container.add_object(content))
+
+    # Will contain tuples `(hashkey, exists)`` [where `exists` is a Boolean]
+    existence_array = []
+    for hashkey in hashkeys_packed:
+        existence_array.append((hashkey, True))
+    for hashkey in hashkeys_loose:
+        existence_array.append((hashkey, True))
+    for idx in range(num_files_half):
+        existence_array.append(('UNKNOWN{}'.format(idx), False))
+
+    # Shuffle pairs
+    random.shuffle(existence_array)
+
+    hashkeys_to_check, expected_result = zip(*existence_array)
+
+    result = benchmark(temp_container.has_objects, hashkeys_to_check)
+
+    # I use `set(data)` because if they are identical, they get the same UUID
+    assert result == list(expected_result)


### PR DESCRIPTION
The bulk method is provided for efficiency reasons, and the
`has_object` method for convenience.

The bulk operation reuses the internal methods, at the cost
of opening the files one by one. By using the internal methods,
however, at least packed files are opened only once per pack file.

Added a performance test, and we will improve performance later
(e.g. at least not opening the loose ones).

Fixes #45

Co-authored-by: Sebastiaan Huber <sebastiaan.huber@epfl.ch>

(since I'm using part of his original implementation of the test)

Replaces #46, so it closes #46 when merged