### PR TITLE
Add the `mode` property to the `PackedObjectReader`

### DIFF
--- a/disk_objectstore/utils.py
+++ b/disk_objectstore/utils.py
@@ -237,6 +237,10 @@ class PackedObjectReader:
     length of the given object."""
 
     @property
+    def mode(self):
+        return self._fhandle.mode
+
+    @property
     def seekable(self):
         """Return whether object supports random access."""
         return False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -485,6 +485,15 @@ def test_packed_object_reader():
         assert packed_reader.read() == bytestream[offset:]
 
 
+def test_packed_object_reader_mode():
+    """Test the ``PackedObjectReader.mode`` property."""
+    with tempfile.TemporaryFile() as handle:
+        reader = utils.PackedObjectReader(handle, 0, 0)
+
+        assert hasattr(reader, 'mode')
+        assert reader.mode == handle.mode
+
+
 def test_stream_decompresser():
     """Test the stream decompresser."""
     # A short binary string (1025 bytes, an odd number to avoid possible alignments with the chunk size)


### PR DESCRIPTION
Fixes #57 

This simply returns the mode of the file handle that was passed to the
constructor of the `PackedObjectReader`. This is useful since certain
consumers might not be able to or want to resort to duck-typing and may
want to explicitly check the mode of the filelike object.