### PR TITLE
Fix concurrency problems in Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ container.get_object_content(hash2)
 hash3 = container.add_object(b'third_content')
 ```
 
+
 ## Advanced usage
 This repository is designed both for performance and for having a low memory footprint.
 Therefore, it provides bulk operations and the possibility to access objects as streams.

--- a/disk_objectstore/examples/example_objectstore.py
+++ b/disk_objectstore/examples/example_objectstore.py
@@ -128,6 +128,10 @@ def main(num_files, min_size, max_size, directly_to_pack, path, clear, num_bulk_
         container.pack_all_loose(compress=compress_packs)
         tot_time = time.time() - start
         print('Time to pack all loose objects: {:.4} s'.format(tot_time))
+        start = time.time()
+        container.clean_storage()
+        tot_time = time.time() - start
+        print('Time to clean storage: {:.4} s'.format(tot_time))
 
         # Check that all loose files are gone
         counts = container.count_objects()

--- a/disk_objectstore/exceptions.py
+++ b/disk_objectstore/exceptions.py
@@ -23,3 +23,14 @@ class InconsistentContent(Exception):
     This should really never happen, if it happens it might either be a bug in the implementation, some serious
     problem e.g. with your disk, or someone accessing the directory manually and modifying the files.
     """
+
+
+class DynamicInconsistentContent(InconsistentContent):
+    """Raised if the content of the repository is inconsistent and this happens while generating the content.
+    This should really never happen, and the same notes hold as the for the parent class ``InconsistentContent``.
+    However, this exception is raised specifically when the content was being operated on, e.g. when
+    trying to replace an object and failing to do so (while the base class can be raised also when the static
+    content is corrupt). So this exception is transient and might be solved by just retrying the operation.
+    However, since this exception should not really happen, it's better not to ignore it, but to investigate
+    why it has been raised.
+    """

--- a/disk_objectstore/exceptions.py
+++ b/disk_objectstore/exceptions.py
@@ -23,15 +23,3 @@ class InconsistentContent(Exception):
     This should really never happen, if it happens it might either be a bug in the implementation, some serious
     problem e.g. with your disk, or someone accessing the directory manually and modifying the files.
     """
-
-
-class DynamicInconsistentContent(InconsistentContent):
-    """Raised if the content of the repository is inconsistent and this happens while generating the content.
-
-    This should really never happen, and the same notes hold as the for the parent class ``InconsistentContent``.
-    However, this exception is raised specifically when the content was being operated on, e.g. when
-    trying to replace an object and failing to do so (while the base class can be raised also when the static
-    content is corrupt). So this exception is transient and might be solved by just retrying the operation.
-    However, since this exception should not really happen, it's better not to ignore it, but to investigate
-    why it has been raised.
-    """

--- a/disk_objectstore/utils.py
+++ b/disk_objectstore/utils.py
@@ -11,7 +11,7 @@ import zlib
 
 from contextlib import contextmanager
 
-from .exceptions import ModificationNotAllowed, ClosingNotAllowed, DynamicInconsistentContent
+from .exceptions import ModificationNotAllowed, ClosingNotAllowed
 
 
 class LazyOpener:
@@ -170,51 +170,49 @@ class ObjectWriter:
                 if os.path.exists(dest_loose_object):
                     if self._trust_existing:
                         # I trust that the object is correct: I just return
+                        # Note: if another process is deleting the file at the same time (right after),
+                        # it will be deleted. But this is OK - the deletion is in an independent process,
+                        # an if it happens only microseconds or seconds after the write, the effect is the same:
+                        # the object is deleted and the caller of this function will not find it anymore.
                         return
                     # I do not trust the object is correct.
                     # This might still not be perfect: while I check, another
                     # process might in the meantime rewrite it again, and this might
-                    # be wrong. But this is very difficult to catch
+                    # be wrong. But this is very difficult to catch, and in general
+                    # the situation in which a process writes a corrupt node is really an error
                     existing_checksum = _compute_hash_for_filename(filename=dest_loose_object, hash_type=self.hash_type)
                     if existing_checksum == self._hashkey:
                         # The existing object has the correct hash, I just return.
                         return
-                    # The existing object has the wrong hash! I am going to assume where was a problem
-                    # and I will just remove it and overwrite it.
-                    # This means that the object will *not* be there for some time.
-                    # But this should be ok, because it was corrupted, so nobody should really be
-                    # using it...
-                    # Note: this would really be needed only on Windows, on Unix os.rename will silently replace
-                    # the existing file
-                    # Note that in reality I could end up deleting a 'good' file written by another process
-                    # performing the exact same operation. But I will write it again below so this will only
-                    # create a small window of time in which it does not exist (and I don't know if there is
-                    # a way around it). This anyway happens only for existing but corrupted loose objects.
-                    os.remove(dest_loose_object)
-                # This is an atomic operation, at least according to this website:
-                # https://alexwlchan.net/2019/03/atomic-cross-filesystem-moves-in-python/
-                # but needs to be on the same filesystem (this should always be the case for us)
-                # Note that instead shutil.move is not guaranteed to be atomic!
-                # Also: on Linux, this performs a silent overwrite if the file exists.
-                # Instead, it raises OSError on Windows if the file exists.
-                # The Linux behavior is ok: in this case, two processes were writing at almost the same time;
-                # we assume it's ok to take either of them (the second winning)
-                # On Windows, we need to take special action
-                try:
-                    os.rename(self._obj_path, dest_loose_object)
-                except OSError:
-                    # NOTE! This branch only happens on Windows, see above
-                    # A file with the same name was written in the meantime by someone else...
-                    # We do a final check of its content
-                    existing_checksum = _compute_hash_for_filename(filename=dest_loose_object, hash_type=self.hash_type)
-                    if existing_checksum == self._hashkey:
-                        # The existing object that has appeared in the meantime is OK. Fine, has the correct hash,
-                        # I just return.
+                    # If existing_checksum is None, the file has been removed in the meantime.
+                    # It could be a delete of the object: then, for consistency with the logic above,
+                    # I decide that the two operations that happened almost at the same time could
+                    # have happened in swapped order, and I don't write it back.
+                    # Or it's a packing operation (and then it's OK to not put the file back).
+                    # I therefore just return
+                    if existing_checksum is None:
                         return
-                    raise DynamicInconsistentContent(
-                        "I am trying to create loose object with hash key '{}', "
-                        'but it keeps reappearing with wrong content!'.format(self._hashkey)
-                    )
+
+                # If I am here, there are two options:
+                # 1. The object did not exist
+                # 2. The file is there but its content is wrong. In this case I want to overwrite the object.
+
+                # I therefore call a 'replace' call, that should be an atomic operation
+                # Notes (on os.replace vs os.rename):
+                # - os.rename() on Linux is atomic (see e.g. also
+                #   https://alexwlchan.net/2019/03/atomic-cross-filesystem-moves-in-python/
+                #   but needs to be on the same filesystem (this should always be the case for us)
+                # - Remembe that instead shutil.move is not guaranteed to be atomic!
+                # - os.rename performs a silent overwrite if the file exists on Posix, so would be enough
+                #   on Linux/Mac; instead, it raises OSError on Windows if the file exists.
+                # - we use instead os.replace that, on Windows, calls a rename with the correct flags
+                #   to overwrite an existing destination.
+                # NOTE: for now I don't catch any exception on Windows. I am not sure of which race conditions
+                # might happen yet, e.g. if someone has opened the file.
+                # But either this was corrupt and open, and then it shouldn't really be open by someone...
+                # Or it had been deleted in the meantime, so I should be creating it (someone might be reopening
+                # it at the same time, this is probably a rare but possible race condition)
+                os.replace(self._obj_path, dest_loose_object)
 
                 # Flush also the parent directory, see e.g.
                 # https://blog.gocept.com/2013/07/15/reliable-file-updates-with-python/
@@ -453,19 +451,22 @@ def _compute_hash_for_filename(filename, hash_type):
 
     :param filename: a filename to a file to check.
     :param hash_type: a valid string as recognised by the _get_hash function
-    :return: the hash hexdigest (the hash key)
+    :return: the hash hexdigest (the hash key), or `None` if the file does not exist
     """
     _chunksize = 524288
 
     hasher = _get_hash(hash_type)()
-    with open(filename, 'rb') as fhandle:
-        while True:
-            chunk = fhandle.read(_chunksize)
-            hasher.update(chunk)
+    try:
+        with open(filename, 'rb') as fhandle:
+            while True:
+                chunk = fhandle.read(_chunksize)
+                hasher.update(chunk)
 
-            if not chunk:
-                # Empty returned value: EOF
-                break
+                if not chunk:
+                    # Empty returned value: EOF
+                    break
+    except FileNotFoundError:
+        return None
 
     return hasher.hexdigest()
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -13,8 +13,9 @@ CONCURRENT_DIR = os.path.join(THIS_FILE_DIR, 'concurrent_tests')
 NUM_WORKERS = 4
 
 
-@pytest.mark.xfail(os.name == 'nt', reason='Still some problems on Windows, see #4')
-def test_concurrency(temp_dir):
+# Do the same test 20 times
+@pytest.mark.parametrize('repetition', list(range(20)))
+def test_concurrency(temp_dir, repetition):  # pylint: disable=unused-argument
     """Test to run concurrently many workers creating objects, and at the same time one packer.
 
     This is needed to see that indeed these operations can happen at the same time.

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -13,9 +13,10 @@ CONCURRENT_DIR = os.path.join(THIS_FILE_DIR, 'concurrent_tests')
 NUM_WORKERS = 4
 
 
-# Do the same test 5 times (5*2*2 = 20 total tests)
-@pytest.mark.parametrize('repetition', list(range(5)))
-@pytest.mark.parametrize('with_packing', [True, False])
+# Do the same test multiple times (repetition*2*2); I set it to 1, but can be increased for debugging
+@pytest.mark.xfail(os.name == 'nt', reason='Still some problems on Windows, see #37')
+@pytest.mark.parametrize('repetition', list(range(1)))
+@pytest.mark.parametrize('with_packing', [True])  #, False])  # If it works with packing, no need to test also without
 @pytest.mark.parametrize('max_size', [1, 1000])
 def test_concurrency(temp_dir, repetition, with_packing, max_size):  # pylint: disable=unused-argument, too-many-statements, too-many-locals
     """Test to run concurrently many workers creating (loose) objects and (possibly) a single concurrent packer.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 """Test of the utils wrappers."""
 import functools
+import hashlib
 import io
 import os
 import tempfile
@@ -9,9 +10,12 @@ import psutil
 import pytest
 
 from disk_objectstore import utils
+
 import disk_objectstore.exceptions as exc
 
-os._actual_remove_function = os.remove  # pylint: disable=protected-access
+# I need these definitions later for the mocked function
+os._actual_replace_function = os.replace  # pylint: disable=protected-access
+utils._actual_compute_hash_for_filename = utils._compute_hash_for_filename  # pylint: disable=protected-access
 
 
 def test_lazy_opener_read():
@@ -254,11 +258,10 @@ def test_object_writer_existing_corrupted_reappears(  # pylint: disable=invalid-
     ):
     """Test that the ObjectWriter replaces an existing corrupted (wrong hash) loose object.
 
-    Moreover, if the corrupted file is deleted and it quickly reappears, make sure that the code does not crash.
-    In this test, the `os.remove` call is patched for the specific loose file. If reappears_corrupted is True,
-    the file that will reappear as soon as it's deleted internally is going still to be corrupted. Otherwise,
-    it will be a correct content (i.e., with the correct hash key, as if another process has created it at the same
-    time)."""
+    Moreover, if reappears_corrupted is True, I patch `os.replace` to overwrite the destination with corrupted content
+    are re-open it in read mode before calling the replace function, to check if I get any exception (especially on
+    Windows).
+    """
     sandbox_folder = os.path.join(temp_dir, 'sandbox')
     loose_folder = os.path.join(temp_dir, 'loose')
     loose_prefix_len = 2
@@ -292,36 +295,33 @@ def test_object_writer_existing_corrupted_reappears(  # pylint: disable=invalid-
         trust_existing=trust_existing
     )
 
-    def mockremove(path, protected_path, new_bytes_content):
-        """Remove a file, mocking the os.remove functionality."""
-        # I renamed this at module load to avoid infinite recursion
-        os._actual_remove_function(path)  # pylint: disable=protected-access
-        if os.path.realpath(path) == os.path.realpath(protected_path):
+    def mockreplace(src, dest, mocked_dest, new_bytes_content):
+        """Replace a file, but if the dest is the mocked destination, before replacing, opens the existing file.
+
+        It also rewrites the file with the new_bytes_content beforehand.
+        """
+        if os.path.realpath(dest) == os.path.realpath(mocked_dest):
             # Write back the file, with possibly a different content
-            with open(path, 'wb') as fhandle:
+            with open(dest, 'wb') as fhandle:
                 fhandle.write(new_bytes_content)
+
+                # Call the actual replace function, but while the file is open in read mode
+                with open(dest, 'rb') as fhandle:
+                    os._actual_replace_function(src, dest)  # pylint: disable=protected-access
+        else:
+            # It's a different path: just pipe through
+            # I renamed this at module load to avoid infinite recursion, see above
+            os._actual_replace_function(src, dest)  # pylint: disable=protected-access
 
     new_bytes_content = corrupted_content if reappears_corrupted else content
     monkeypatch.setattr(
-        os, 'remove', functools.partial(mockremove, protected_path=loose_file, new_bytes_content=new_bytes_content)
+        os, 'replace', functools.partial(mockreplace, mocked_dest=loose_file, new_bytes_content=new_bytes_content)
     )
 
-    if os.name == 'nt' and not trust_existing and reappears_corrupted:
-        # On windows, I am not sure it's possible to do an atomic overwrite.
-        # Currently this library implements logic such that if the file reappears,
-        # but its content is correct, no error is raised. But if the file reappears
-        # and its content is corrupted, an exception is raised (this should really
-        # never happen, and if it happens, it means there is something really wrong!)
-        with pytest.raises(exc.DynamicInconsistentContent):
-            with object_writer as fhandle:
-                # Write some content (this should end up in the same `loose_file` location)
-                fhandle.write(content)
-    else:
-        # On POSIX, the os.rename is going to silently overwrite the existing file.
-        # Therefore, I expect that the file write will go through without exceptions.
-        with object_writer as fhandle:
-            # Write some content (this should end up in the same `loose_file` location)
-            fhandle.write(content)
+    # I would like that on any OS, the object_writer works and does it job also in this condition
+    with object_writer as fhandle:
+        # Write some content (this should end up in the same `loose_file` location)
+        fhandle.write(content)
 
     # Check the end condition:
     # nothing in the sandbox, nothing new in the loose_folder
@@ -344,8 +344,137 @@ def test_object_writer_existing_corrupted_reappears(  # pylint: disable=invalid-
             assert object_content == corrupted_content
         else:
             # In all other cases, if I don't trust existing files, the content should have been replaced,
-            # and if the DynamicInconsistentContent exception wasn't raised, the content must be correct
+            # and the content must be correct
             assert object_content == content
+
+
+@pytest.mark.parametrize('object_existed', [True, False])
+def test_object_writer_deleted_while_checking_content(  # pylint: disable=invalid-name
+        temp_dir, object_existed, monkeypatch
+    ):
+    """Test that the ObjectWriter works also when the destination gets deleted while checking.
+
+    I check both the case in which the object existed, and the one in which it didn't (in which case, the
+    mocking shouldn't do anything).
+    """
+    sandbox_folder = os.path.join(temp_dir, 'sandbox')
+    loose_folder = os.path.join(temp_dir, 'loose')
+    loose_prefix_len = 2
+    hash_type = 'sha256'
+    trust_existing = False  # This branch is only called in this case
+    os.mkdir(sandbox_folder)
+    os.mkdir(loose_folder)
+
+    content = b'523453dfvsd'
+    hasher = utils._get_hash(hash_type=hash_type)()  # pylint: disable=protected-access
+    hasher.update(content)
+    hashkey = hasher.hexdigest()
+
+    # I write already the loose destination
+    loose_file = os.path.join(loose_folder, hashkey[:loose_prefix_len], hashkey[loose_prefix_len:])
+    os.mkdir(os.path.dirname(loose_file))
+
+    # Create the object, if `object_existed` is True (meaning that it existed before calling the ObjectWriter)
+    if object_existed:
+        with open(loose_file, 'wb') as fhandle:
+            fhandle.write(content)
+
+    # Check the starting condition
+    assert not os.listdir(sandbox_folder)
+    assert len(os.listdir(loose_folder)) == 1
+    assert len(os.listdir(os.path.dirname(loose_file))) == (1 if object_existed else 0)
+
+    def mock_compute_hash(filename, hash_type, mocked_filename):
+        """Replace lowelevel_utils._compute_hash_for_filename by first deleting the destination file.
+
+        .. note:: this is performed only for the mocked filename.
+
+        This should return `None` but I prefer mocking in case the behavior is changed in the future.
+        """
+        # Delete the filename before calling through the actual function (if it exists)
+        if os.path.realpath(filename) == os.path.realpath(mocked_filename) and os.path.exists(filename):
+            os.remove(filename)
+
+        # Now, just pipe through
+        # I renamed this at module load to avoid infinite recursion, see above
+        utils._actual_compute_hash_for_filename(filename, hash_type)  # pylint: disable=protected-access
+
+    monkeypatch.setattr(
+        utils, '_compute_hash_for_filename', functools.partial(mock_compute_hash, mocked_filename=loose_file)
+    )
+
+    object_writer = utils.ObjectWriter(
+        sandbox_folder=sandbox_folder,
+        loose_folder=loose_folder,
+        loose_prefix_len=loose_prefix_len,
+        hash_type=hash_type,
+        trust_existing=trust_existing
+    )
+
+    with object_writer as fhandle:
+        # Write some content (this should end up in the same `loose_file` location)
+        fhandle.write(content)
+
+    # Check the end condition
+    # nothing in the sandbox, and:
+    # - NOTHING in the loose_folder if object_existed is True: someone deleted in the meantime, and it's
+    #   the choice of the current implementation that the file is not put back in place,
+    #   as discussed in the comments in the ObjectWriter class
+    # - a file if the file wasn't there from the beginning
+    assert not os.listdir(sandbox_folder)
+    assert len(os.listdir(loose_folder)) == 1
+    assert len(os.listdir(os.path.dirname(loose_file))) == (0 if object_existed else 1)
+
+
+@pytest.mark.parametrize('trust_existing', [True, False])
+def test_object_writer_existing_OK(temp_dir, trust_existing):  # pylint: disable=invalid-name
+    """Test that the ObjectWriter works if the loose object already exists (with the correct content)."""
+    sandbox_folder = os.path.join(temp_dir, 'sandbox')
+    loose_folder = os.path.join(temp_dir, 'loose')
+    loose_prefix_len = 2
+    hash_type = 'sha256'
+    os.mkdir(sandbox_folder)
+    os.mkdir(loose_folder)
+
+    content = b'523453dfvsd'
+    hasher = utils._get_hash(hash_type=hash_type)()  # pylint: disable=protected-access
+    hasher.update(content)
+    hashkey = hasher.hexdigest()
+
+    # Write already the content in place
+    loose_file = os.path.join(loose_folder, hashkey[:loose_prefix_len], hashkey[loose_prefix_len:])
+    os.mkdir(os.path.dirname(loose_file))
+    with open(loose_file, 'wb') as fhandle:
+        fhandle.write(content)
+
+    # Check the starting condition
+    assert not os.listdir(sandbox_folder)
+    assert len(os.listdir(loose_folder)) == 1
+    assert len(os.listdir(os.path.dirname(loose_file))) == 1
+
+    object_writer = utils.ObjectWriter(
+        sandbox_folder=sandbox_folder,
+        loose_folder=loose_folder,
+        loose_prefix_len=loose_prefix_len,
+        hash_type=hash_type,
+        trust_existing=trust_existing
+    )
+
+    with object_writer as fhandle:
+        # Write some content (this should end up in the same `loose_file` location)
+        fhandle.write(content)
+
+    # Check the end condition:
+    # nothing in the sandbox, nothing new in the loose_folder
+    assert not os.listdir(sandbox_folder)
+    assert len(os.listdir(loose_folder)) == 1
+    assert len(os.listdir(os.path.dirname(loose_file))) == 1
+
+    # Check now the content
+    with open(loose_file, 'rb') as fhandle:
+        object_content = fhandle.read()
+
+    assert object_content == content
 
 
 @pytest.mark.parametrize('trust_existing', [True, False])
@@ -594,6 +723,8 @@ def test_hash_writer_wrapper(temp_dir, hash_type, expected_hash):
         wrapped.flush()
         assert wrapped.hexdigest() == expected_hash
         assert wrapped.hash_type == hash_type
+        # Check the mode
+        assert wrapped.mode == 'wb'
 
     with open(os.path.join(temp_dir, filename), 'rb') as fhandle:
         assert fhandle.read() == content
@@ -610,3 +741,26 @@ def test_chunk_iterator():
 
     # Check for lengths that give a remainder
     assert list(utils.chunk_iterator(iter(range(10)), 3)) == [(0, 1, 2), (3, 4, 5), (6, 7, 8), (9,)]
+
+
+def test_compute_hash_from_filename(temp_dir):
+    """Check the functionality of the _compute_hash_from_filename function."""
+    content = b'2345j43'
+    expected_hash = hashlib.sha256(content).hexdigest()
+
+    fname = os.path.join(temp_dir, 'testfile')
+
+    with open(fname, 'wb') as fhandle:
+        fhandle.write(content)
+
+    assert utils._compute_hash_for_filename(fname, 'sha256') == expected_hash  # pylint: disable=protected-access
+    assert utils._compute_hash_for_filename(  # pylint: disable=protected-access
+        os.path.join(temp_dir, 'NOT_EXISTENT_FILE'), 'sha256') is None
+
+
+def test_is_known_hash():
+    """Check the functionality of the is_known_hash function."""
+    # At least sha256 should be supported
+    assert utils.is_known_hash('sha256')
+    # A weird string should not be a valid known hash
+    assert not utils.is_known_hash('SOME_UNKNOWN_HASH_TYPE')


### PR DESCRIPTION
This also changes quite a few things and the logic behind. In particular:

- `pack_all_loose` now does not delete loose files that have been packed. A new method `clean_storage` needs to be called to reclaim space. This allows to avoid problems on Mac and fixes #43 
- we use `os.replace` instead of removing + renaming, that is better in terms of atomicity
- the function `_compute_hash_for_filename` now returns None rather than raising if the file does not exist (e.g. it has been deleted in the meantime)
- the output of the periodic_worker and of the test_concurrency have been augmented with debug information in case of errors to facilitate debugging
- test_concurrency now is ready to be run multiple times via parameters of pytest, to increase probability of showing the concurrency errors (will help while looking at #37 for Windows
- tests have been adapted
- `test_utils` now try to achieve alone a full coverage of the `utils.py` module