### PR TITLE
Fix to the hash calculation when writing to compressed packs.

### DIFF
--- a/disk_objectstore/utils.py
+++ b/disk_objectstore/utils.py
@@ -513,13 +513,13 @@ class ZeroStream:
 def is_known_hash(hash_type):
     """Return True if the hash_type is known, False otherwise."""
     try:
-        _get_hash(hash_type)
+        get_hash(hash_type)
         return True
     except ValueError:
         return False
 
 
-def _get_hash(hash_type):
+def get_hash(hash_type):
     """Return a hash class with an update method and a hexdigest method."""
     known_hashes = {
         'sha256': hashlib.sha256,
@@ -537,12 +537,12 @@ def _compute_hash_for_filename(filename, hash_type):
     Will read the file in chunks.
 
     :param filename: a filename to a file to check.
-    :param hash_type: a valid string as recognised by the _get_hash function
+    :param hash_type: a valid string as recognised by the get_hash function
     :return: the hash hexdigest (the hash key), or `None` if the file does not exist
     """
     _chunksize = 524288
 
-    hasher = _get_hash(hash_type)()
+    hasher = get_hash(hash_type)()
     try:
         with open(filename, 'rb') as fhandle:
             while True:
@@ -574,7 +574,7 @@ class HashWriterWrapper:
         assert 'b' in self._write_stream.mode
         self._hash_type = hash_type
 
-        self._hash = _get_hash(self._hash_type)()
+        self._hash = get_hash(self._hash_type)()
         self._position = self._write_stream.tell()
 
     @property

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -270,7 +270,7 @@ def test_object_writer_existing_corrupted_reappears(  # pylint: disable=invalid-
     os.mkdir(loose_folder)
 
     content = b'523453dfvsd'
-    hasher = utils._get_hash(hash_type=hash_type)()  # pylint: disable=protected-access
+    hasher = utils.get_hash(hash_type=hash_type)()
     hasher.update(content)
     hashkey = hasher.hexdigest()
 
@@ -375,7 +375,7 @@ def test_object_writer_deleted_while_checking_content(  # pylint: disable=invali
     os.mkdir(loose_folder)
 
     content = b'523453dfvsd'
-    hasher = utils._get_hash(hash_type=hash_type)()  # pylint: disable=protected-access
+    hasher = utils.get_hash(hash_type=hash_type)()
     hasher.update(content)
     hashkey = hasher.hexdigest()
 
@@ -446,7 +446,7 @@ def test_object_writer_existing_OK(temp_dir, trust_existing):  # pylint: disable
     os.mkdir(loose_folder)
 
     content = b'523453dfvsd'
-    hasher = utils._get_hash(hash_type=hash_type)()  # pylint: disable=protected-access
+    hasher = utils.get_hash(hash_type=hash_type)()
     hasher.update(content)
     hashkey = hasher.hexdigest()
 
@@ -497,7 +497,7 @@ def test_object_writer_existing_corrupted(temp_dir, trust_existing):  # pylint: 
     os.mkdir(loose_folder)
 
     content = b'523453dfvsd'
-    hasher = utils._get_hash(hash_type=hash_type)()  # pylint: disable=protected-access
+    hasher = utils.get_hash(hash_type=hash_type)()
     hasher.update(content)
     hashkey = hasher.hexdigest()
 


### PR DESCRIPTION
The hasher was applied in the wrong place
(while writing rather than while reading) therefore it was hashing
*after* compression and storing with the wrong hash.
The hasher should run on the read stream instead.

We fix this and we also add tests.
We also add a validation while packing loose objects, so we avoid
to pack files that are corrupt (rasing an Exception).

Fixes #73