### PR TITLE
Fix concurrency problems on Windows

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,3 +11,4 @@ pytest==5.4.1
 pytest-cov==2.8.1
 pytest-benchmark==3.2.3
 memory-profiler==0.57.0
+pywin32==228; platform_system == "Windows"

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -1100,7 +1100,10 @@ class Container:  # pylint: disable=too-many-public-methods
                             # The second parameter is `None` since we are not computing the hash
                             # We can instead pass the hash algorithm and assert that it is correct
                             obj.size, new_hashkey = self._write_data_to_packfile(
-                                pack_handle=pack_handle, read_handle=loose_handle, compress=compress, hash_type=hash_type
+                                pack_handle=pack_handle,
+                                read_handle=loose_handle,
+                                compress=compress,
+                                hash_type=hash_type
                             )
                     except PermissionError:
                         # This might happen if the file is being written and is locked.

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -1073,7 +1073,6 @@ class Container:  # pylint: disable=too-many-public-methods
             last_pack_int_id = pack_int_id
             # Avoid concurrent writes on the pack file
             with self.lock_pack(str(pack_int_id)) as pack_handle:
-                loose_objects_this_pack = []
                 # Inner loop: continue until when there is a file, or
                 # if we need to change pack (in this case `break` is called)
                 while loose_objects:
@@ -1091,25 +1090,28 @@ class Container:  # pylint: disable=too-many-public-methods
 
                     # Get next hash key to process
                     loose_hashkey = loose_objects.pop()
-                    # Keep track of it for later deletion
-                    loose_objects_this_pack.append(loose_hashkey)
 
                     obj = Obj(hashkey=loose_hashkey)
                     obj.pack_id = pack_int_id
                     obj.compressed = compress
                     obj.offset = pack_handle.tell()
-                    with open(self._get_loose_path_from_hashkey(loose_hashkey), 'rb') as loose_handle:
-                        # The second parameter is `None` since we are not computing the hash
-                        # We can instead pass the hash algorithm and assert that it is correct
-                        obj.size, new_hashkey = self._write_data_to_packfile(
-                            pack_handle=pack_handle, read_handle=loose_handle, compress=compress, hash_type=hash_type
-                        )
-                        if hash_type and new_hashkey != loose_hashkey:
-                            raise InconsistentContent(
-                                "Error when packing object '{}': re-computed hash is different! '{}'".format(
-                                    loose_hashkey, new_hashkey
-                                )
+                    try:
+                        with open(self._get_loose_path_from_hashkey(loose_hashkey), 'rb') as loose_handle:
+                            # The second parameter is `None` since we are not computing the hash
+                            # We can instead pass the hash algorithm and assert that it is correct
+                            obj.size, new_hashkey = self._write_data_to_packfile(
+                                pack_handle=pack_handle, read_handle=loose_handle, compress=compress, hash_type=hash_type
                             )
+                    except PermissionError:
+                        # This might happen if the file is being written and is locked.
+                        # In this case, don't pack this file. We will pack it in a future call.
+                        continue
+                    if hash_type and new_hashkey != loose_hashkey:
+                        raise InconsistentContent(
+                            "Error when packing object '{}': re-computed hash is different! '{}'".format(
+                                loose_hashkey, new_hashkey
+                            )
+                        )
                     obj.length = pack_handle.tell() - obj.offset
                     session.add(obj)
 
@@ -1126,7 +1128,7 @@ class Container:  # pylint: disable=too-many-public-methods
             # If we are here, things should be guaranteed by SQLite to be written to disk.
             # Then, it would be safe to already do some clean up of loose objects that are now packed,
             # and by doing it here we would do it after each pack.
-            # This would mean removing objects that are in `loose_objects_this_pack`.
+            # This would mean keeping track of the loose objects added to packs, and removing them.
             # HOWEVER, while this would work fine on Linux, there are concurrency issues both
             # on Mac and on Windows (see issues #37 and #43). Therefore, I do NOT delete them,
             # and deletion is deferred to a manual clean-up operation.

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -1284,6 +1284,3 @@ class Container:  # pylint: disable=too-many-public-methods
                 # This can happen on Windows if one of the loose objects is still open.
                 # I just ignore, I will remove it in a future call of this method.
                 pass
-
-        # TODO: implement logic to check, remove duplicates if the corresponding existing
-        # (loose or packed) file exists and is correct, otherwise replace, or show an error.

--- a/disk_objectstore/exceptions.py
+++ b/disk_objectstore/exceptions.py
@@ -23,14 +23,3 @@ class InconsistentContent(Exception):
     This should really never happen, if it happens it might either be a bug in the implementation, some serious
     problem e.g. with your disk, or someone accessing the directory manually and modifying the files.
     """
-
-
-class DynamicInconsistentContent(InconsistentContent):
-    """Raised if the content of the repository is inconsistent and this happens while generating the content.
-    This should really never happen, and the same notes hold as the for the parent class ``InconsistentContent``.
-    However, this exception is raised specifically when the content was being operated on, e.g. when
-    trying to replace an object and failing to do so (while the base class can be raised also when the static
-    content is corrupt). So this exception is transient and might be solved by just retrying the operation.
-    However, since this exception should not really happen, it's better not to ignore it, but to investigate
-    why it has been raised.
-    """

--- a/disk_objectstore/utils.py
+++ b/disk_objectstore/utils.py
@@ -239,7 +239,7 @@ class ObjectWriter:
                     # the same file
                     try:
                         os.rename(self._obj_path, dest_loose_object)
-                    except PermissionError:
+                    except FileExistsError:
                         # NOTE! This branch only happens on Windows, when the
                         # file with the same name was opened in the meantime by someone else...
                         if self._trust_existing:

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     extras_require={
         'dev': [
             'profilehooks', 'psutil', 'click', 'pre-commit', 'yapf', 'prospector', 'pylint', 'pytest', 'pytest-cov',
-            'memory-profiler'
+            'memory-profiler', 'pywin32; platform_system == "Windows"'
         ],
     },
     packages=find_packages(),

--- a/tests/concurrent_tests/periodic_worker.py
+++ b/tests/concurrent_tests/periodic_worker.py
@@ -155,10 +155,10 @@ def main(num_files, min_size, max_size, path, repetitions, wait_time, shared_fol
                 except NotExistent:
                     retrieved_content[obj_hashkey] = None
                     metas[obj_hashkey] = {'type': 'missing'}  # I don't put all the rest for simplicity
-                except PermissionError as exc:
+                except (PermissionError, FileExistsError) as exc:
                     # This sometimes happen on Windows (I think during packing), see issue #37
                     # The error message typically shows the error and the path, showing if it's loose
-                    print('WARNING/ERROR: I got a permission error, message: {}'.format(str(exc)))
+                    print('WARNING/ERROR: I got an exception, message: {}'.format(str(exc)))
 
                     # Before re-raising, I try to get the same object again, to see if this now works and is packed
                     # (or it crashes again!)
@@ -206,10 +206,10 @@ def main(num_files, min_size, max_size, path, repetitions, wait_time, shared_fol
         for obj_hashkey in all_hashkeys:
             try:
                 content = container.get_object_content(obj_hashkey)
-            except PermissionError as exc:
+            except (PermissionError, FileExistsError) as exc:
                 # This sometimes happen on Windows (I think during packing), see issue #37
                 # The error message typically shows the error and the path, showing if it's loose
-                print('WARNING/ERROR: I got a permission error, message: {}'.format(str(exc)))
+                print('WARNING/ERROR: I got an exception, message: {}'.format(str(exc)))
 
                 # Before re-raising, I try to get the same object again, to see if this now works and is packed
                 # (or it crashes again!)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,21 @@ import pytest
 from disk_objectstore import Container
 
 
+def pytest_addoption(parser):
+    """Parse a new option for the number of repetitions for the concurrency tests."""
+    parser.addoption(
+        '--concurrency-repetitions', type=int, default=1, help='Specify how many time to repeat the concurrency tests'
+    )
+
+
+def pytest_generate_tests(metafunc):
+    """Define a new fixture `concurrency_repetition_index` with the index of the repetition for concurrency tests.
+
+    The number of repetitions can be specified on the command line with ``--concurrency-repetitions=3``."""
+    if 'concurrency_repetition_index' in metafunc.fixturenames:
+        metafunc.parametrize('concurrency_repetition_index', range(metafunc.config.option.concurrency_repetitions))
+
+
 @pytest.fixture(scope='function')
 def temp_container(temp_dir):  # pylint: disable=redefined-outer-name
     """Return an object-store container in a given temporary directory.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -289,20 +289,11 @@ def test_rename_when_existing(temp_dir):
 
 # Run only on Windows where we want to check the locking behavior
 @pytest.mark.skipif(os.name != 'nt', reason='This test only makes sense on Windows')
-def test_exclusive_mode_windows(temp_dir):
+def test_exclusive_mode_windows(temp_dir, lock_file_on_windows):
     """Test that indeed I can open a file with exclusive lock on Windows.
 
     This means someone else cannot even open the file in read mode.
     """
-    # This should run on Windows, but the linter runs on Ubuntu where these modules
-    # do not exist. Therefore, ignore errors in this function.
-    # pylint: disable=import-error
-    import win32file
-    import pywintypes
-    import win32con
-
-    overlapped = pywintypes.OVERLAPPED()
-
     fname = os.path.join(temp_dir, 'test_file')
     content = b'sfsfdkl;2fd'
 
@@ -313,16 +304,7 @@ def test_exclusive_mode_windows(temp_dir):
     # Now open the file with exclusive locking
     # we need to use os.open
     fd = os.open(fname, os.O_RDONLY)
-    winfd = win32file._get_osfhandle(fd)  # pylint: disable=protected-access
-
-    mode = win32con.LOCKFILE_EXCLUSIVE_LOCK | win32con.LOCKFILE_FAIL_IMMEDIATELY
-    # additional parameters
-    # int : nbytesLow - low-order part of number of bytes to lock
-    # int : nbytesHigh - high-order part of number of bytes to lock
-    # ol=None : PyOVERLAPPED - An overlapped structure
-    # after the first two params: reserved, and nNumberOfBytesToLock
-    # then, overlapped
-    win32file.LockFileEx(winfd, mode, 0, -0x10000, overlapped)
+    lock_file_on_windows(fd)
 
     # I (try to) read the file in a different subprocess
     try:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -288,7 +288,7 @@ def test_rename_when_existing(temp_dir):
 
 
 # Run only on Windows where we want to check the locking behavior
-@pytest.mark.skipif(os.name != 'nt')
+@pytest.mark.skipif(os.name != 'nt', reason='This test only makes sense on Windows')
 def test_exclusive_mode_windows(temp_dir):
     """Test that indeed I can open a file with exclusive lock on Windows.
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -13,11 +13,14 @@ CONCURRENT_DIR = os.path.join(THIS_FILE_DIR, 'concurrent_tests')
 NUM_WORKERS = 4
 
 
-# Do the same test multiple times (repetition*2*2); can be set to > 1 to increase probability of seeing problems
-@pytest.mark.parametrize('repetition', list(range(5)))
+# Do the same test multiple times (repetition*2*2); can be set to > 1 to increase probability of seeing problems.
+# This is specified on the command line when running pytest with ``--concurrency-repetitions=VALUE``
+# (VALUE=1 by default) and passed as `concurrency_repetition_index`.
 @pytest.mark.parametrize('with_packing', [True, False])  # If it works with packing, no need to test also without
 @pytest.mark.parametrize('max_size', [1, 1000])
-def test_concurrency(temp_dir, repetition, with_packing, max_size):  # pylint: disable=unused-argument, too-many-statements, too-many-locals
+def test_concurrency(  # pylint: disable=too-many-statements, too-many-locals, unused-argument
+        temp_dir, with_packing, max_size, concurrency_repetition_index
+    ):
     """Test to run concurrently many workers creating (loose) objects and (possibly) a single concurrent packer.
 
     This is needed to see that indeed these operations can happen at the same time.
@@ -27,6 +30,9 @@ def test_concurrency(temp_dir, repetition, with_packing, max_size):  # pylint: d
 
     .. note:: With max_size=1 I only have a maximum of 256+1 = 257 objects.
       In this way I stress-test also the creation of concurrent identical objects.
+
+    ``concurrency_repetition_index`` is an integer looking over the specified repetitions on the pytest command line.
+    We don't use this variable, it's just used to repeat the run multiple times.
     """
     packer_script = os.path.join(CONCURRENT_DIR, 'periodic_packer.py')
     worker_script = os.path.join(CONCURRENT_DIR, 'periodic_worker.py')

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -13,10 +13,9 @@ CONCURRENT_DIR = os.path.join(THIS_FILE_DIR, 'concurrent_tests')
 NUM_WORKERS = 4
 
 
-# Do the same test multiple times (repetition*2*2); I set it to 1, but can be increased for debugging
-@pytest.mark.xfail(os.name == 'nt', reason='Still some problems on Windows, see #37')
-@pytest.mark.parametrize('repetition', list(range(1)))
-@pytest.mark.parametrize('with_packing', [True])  #, False])  # If it works with packing, no need to test also without
+# Do the same test multiple times (repetition*2*2); can be set to > 1 to increase probability of seeing problems
+@pytest.mark.parametrize('repetition', list(range(5)))
+@pytest.mark.parametrize('with_packing', [True, False])  # If it works with packing, no need to test also without
 @pytest.mark.parametrize('max_size', [1, 1000])
 def test_concurrency(temp_dir, repetition, with_packing, max_size):  # pylint: disable=unused-argument, too-many-statements, too-many-locals
     """Test to run concurrently many workers creating (loose) objects and (possibly) a single concurrent packer.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -502,7 +502,7 @@ def test_object_writer_appears_concurrently(  # pylint: disable=invalid-name, to
 
     # Let's check the content of the file - this should never have changed from what we wrote at the beginning
     with open(loose_file, 'rb') as fhandle:
-        assert loose_file.read() == new_bytes_content
+        assert fhandle.read() == new_bytes_content
 
 
 @pytest.mark.parametrize('dest_is_open', [True, False])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -334,7 +334,7 @@ def test_object_writer_existing_locked(  # pylint: disable=invalid-name
     os.mkdir(duplicates_folder)
 
     content = b'523453dfvsd'
-    hasher = utils._get_hash(hash_type=hash_type)()  # pylint: disable=protected-access
+    hasher = utils.get_hash(hash_type=hash_type)()
     hasher.update(content)
     hashkey = hasher.hexdigest()
 
@@ -414,7 +414,7 @@ def test_object_writer_appears_concurrently(  # pylint: disable=invalid-name, to
     os.mkdir(duplicates_folder)
 
     content = b'523453dfvsd'
-    hasher = utils._get_hash(hash_type=hash_type)()  # pylint: disable=protected-access
+    hasher = utils.get_hash(hash_type=hash_type)()
     hasher.update(content)
     hashkey = hasher.hexdigest()
 


### PR DESCRIPTION
Essentially, one of the main issues is that `os.rename` is atomic on Windows, but while renaming, the file is locked. So there is the possibility that any `open` statement will fail.

We now create a new concept of a `duplicates` folder, where we store e.g. a new `loose` object (one copy per failed attempt, with name `<hashkey>.<random-uuid>`) when we fail to create the loose object (typically during concurrent access) and we cannot check if the current existing object is correct.

Tests with mocking are added to have full coverage (if run on Windows as well).

After this is merged, #72 still needs to be addressed to clean up these copies. Also this folder should be considered in #13 when validating containers.

Fixes #37