### PR TITLE
Implement validation routine

### DIFF
--- a/disk_objectstore/__init__.py
+++ b/disk_objectstore/__init__.py
@@ -2,8 +2,8 @@
 
 It does not require a server running.
 """
-from .container import Container
+from .container import Container, ObjectType
 
-__all__ = ('Container',)
+__all__ = ('Container', 'ObjectType')
 
 __version__ = '0.4.0'

--- a/disk_objectstore/container.py
+++ b/disk_objectstore/container.py
@@ -1460,7 +1460,7 @@ class Container:  # pylint: disable=too-many-public-methods
         current_pos = 0
         with open(pack_path, mode='rb') as pack_handle:
             query = session.query(Obj.hashkey, Obj.size, Obj.offset, Obj.length,
-                                  Obj.compressed).filter(Obj.pack_id == 0).order_by(Obj.offset)
+                                  Obj.compressed).filter(Obj.pack_id == pack_id).order_by(Obj.offset)
             for hashkey, size, offset, length, compressed in query:
                 obj_reader = PackedObjectReader(fhandle=pack_handle, offset=offset, length=length)
                 if compressed:

--- a/disk_objectstore/exceptions.py
+++ b/disk_objectstore/exceptions.py
@@ -23,17 +23,3 @@ class InconsistentContent(Exception):
     This should really never happen, if it happens it might either be a bug in the implementation, some serious
     problem e.g. with your disk, or someone accessing the directory manually and modifying the files.
     """
-
-
-class WrongSize(InconsistentContent):
-    """A subclass of InconsistentContent raised when the size is different than the expected one.
-
-    This can only be checked for packed objects."""
-
-
-class WrongHash(InconsistentContent):
-    """A subclass of InconsistentContent raised when the hash of the content is different from the hash key."""
-
-
-class OverlappingObjects(InconsistentContent):
-    """A subclass of InconsistentContent raised when the two packed objects are overlapping."""

--- a/disk_objectstore/exceptions.py
+++ b/disk_objectstore/exceptions.py
@@ -23,3 +23,17 @@ class InconsistentContent(Exception):
     This should really never happen, if it happens it might either be a bug in the implementation, some serious
     problem e.g. with your disk, or someone accessing the directory manually and modifying the files.
     """
+
+
+class WrongSize(InconsistentContent):
+    """A subclass of InconsistentContent raised when the size is different than the expected one.
+
+    This can only be checked for packed objects."""
+
+
+class WrongHash(InconsistentContent):
+    """A subclass of InconsistentContent raised when the hash of the content is different from the hash key."""
+
+
+class OverlappingObjects(InconsistentContent):
+    """A subclass of InconsistentContent raised when the two packed objects are overlapping."""

--- a/disk_objectstore/utils.py
+++ b/disk_objectstore/utils.py
@@ -763,3 +763,26 @@ def safe_flush_to_disk(fhandle, real_path, use_fullsync=False):
         # Also here call the correct fsync function
         _fsync_function(dirfd)
         os.close(dirfd)
+
+
+def compute_hash_and_size(stream, hash_type):
+    """Given a stream and a hash type, return the hash key (hexdigest) and the total size.
+
+    :param stream: an open stream
+    :param hash_type: the string with a name of a valid hash type
+    :return: a tuple with ``(hash, size)`` where ``hash`` is the hexdigest and ``size`` is the size in bytes
+    """
+    _hash_chunksize = 524288
+    hasher = get_hash(hash_type)()
+
+    # Read and hash all content
+    size = 0
+    while True:
+        next_chunk = stream.read(_hash_chunksize)
+        if not next_chunk:
+            # Empty returned value: EOF
+            break
+        hasher.update(next_chunk)
+        size += len(next_chunk)
+
+    return hasher.hexdigest(), size

--- a/tests/concurrent_tests/periodic_worker.py
+++ b/tests/concurrent_tests/periodic_worker.py
@@ -21,7 +21,7 @@ import time
 import click
 import psutil
 
-from disk_objectstore.container import Container, NotExistent
+from disk_objectstore.container import Container, NotExistent, ObjectType
 from disk_objectstore.models import Obj
 
 MAX_RETRIES_NO_PERM = 1000
@@ -170,7 +170,7 @@ def main(num_files, min_size, max_size, path, repetitions, wait_time, shared_fol
                         metas[obj_hashkey] = meta
                 except NotExistent:
                     retrieved_content[obj_hashkey] = None
-                    metas[obj_hashkey] = {'type': 'missing'}  # I don't put all the rest for simplicity
+                    metas[obj_hashkey] = {'type': ObjectType.MISSING}  # I don't put all the rest for simplicity
                 except (PermissionError, FileExistsError) as exc:
                     # This sometimes happen on Windows (I think during packing), see issue #37
                     # The error message typically shows the error and the path, showing if it's loose

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1195,3 +1195,19 @@ def test_is_known_hash():
     assert utils.is_known_hash('sha256')
     # A weird string should not be a valid known hash
     assert not utils.is_known_hash('SOME_UNKNOWN_HASH_TYPE')
+
+
+@pytest.mark.parametrize('hash_type', ['sha256'])
+def test_compute_hash_and_size(hash_type):
+    """Check the funtion to compute the hash and size."""
+
+    # Try both a small object, and something larger than the chunk size to have full coverage
+    for content in [b'wgarwfsfsdf', b'3gvn3rnv3o' * 100000]:
+        stream = io.BytesIO(content)
+
+        expected_hash = getattr(hashlib, hash_type)(content).hexdigest()
+        expected_size = len(content)
+
+        hashkey, size = utils.compute_hash_and_size(stream, hash_type=hash_type)
+        assert hashkey == expected_hash
+        assert size == expected_size


### PR DESCRIPTION
This also provides a callback so one can show the progress, e.g. in combination with the `tqdm` library.
An example of how to use is in the docstring.

Fixes #13