### PR TITLE
Adding `add_streamed_object` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ You can find various examples of this pattern in the utility wrapper classes in 
 Note also that if you use `get_objects_stream_and_meta`, you can use `meta['size']` to know the size
 of the object before starting to read, so you can e.g. simply do a `.read()` if you know the size is small.
 
+Finally, when writing objects, if the objects are big, instead of reading in memory the whole content, you should use
+the methods ``container.add_streamed_object(stream)`` (loose objects) or ``add_streamed_objects_to_pack(stream_list)``
+(directly to packs).
+
 ## Packing
 As said above, from the user point of view, accessing a `Container` where objects are all loose, all packed, or partially loose and partially packed, does not change anything from the user-interface point of view, but performance might improve a lot after packing.
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -152,6 +152,24 @@ def test_add_get_loose(temp_container, generate_random_data, retrieve_bulk):
         )
 
 
+def test_add_loose_from_stream(temp_container):
+    """Test adding an object from a stream (from an open file, for instance)."""
+    # Write 10*100000 = 1 million bytes, larger than a chunk
+    content = b'0123456789' * 1000000
+
+    with tempfile.NamedTemporaryFile(mode='wb', delete=False) as temp_handle:
+        temp_handle.write(content)
+
+    with open(temp_handle.name, 'rb') as read_handle:
+        hashkey = temp_container.add_streamed_object(read_handle)
+
+    read_content = temp_container.get_object_content(hashkey)
+
+    assert read_content == content
+
+    os.remove(temp_handle.name)
+
+
 @pytest.mark.parametrize('use_compression,retrieve_bulk', [(True, True), (True, False), (False, True), (False, False)])
 def test_add_get_with_packing(temp_container, generate_random_data, use_compression, retrieve_bulk):
     """Add a number of objects (one by one, loose) to the container.


### PR DESCRIPTION
This function allows to add a loose object from an open stream (reducing memory usage for large objects)

Fixes #78